### PR TITLE
Removing 'module-invalid-version-added' from sanity text since 'version' is removed,

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,7 +1,4 @@
 plugins/modules/gluster_peer.py validate-modules:doc-required-mismatch
-plugins/modules/gluster_peer.py validate-modules:module-invalid-version-added
 plugins/modules/gluster_peer.py validate-modules:parameter-list-no-elements
-plugins/modules/gluster_volume.py validate-modules:option-invalid-version-added
 plugins/modules/gluster_volume.py validate-modules:parameter-list-no-elements
-plugins/modules/gluster_heal_info.py validate-modules:module-invalid-version-added
 plugins/modules/gluster_heal_info.py pylint:ansible-deprecated-no-collection-name

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,7 +1,4 @@
 plugins/modules/gluster_peer.py validate-modules:doc-required-mismatch
-plugins/modules/gluster_peer.py validate-modules:module-invalid-version-added
 plugins/modules/gluster_peer.py validate-modules:parameter-list-no-elements
-plugins/modules/gluster_volume.py validate-modules:option-invalid-version-added
 plugins/modules/gluster_volume.py validate-modules:parameter-list-no-elements
-plugins/modules/gluster_heal_info.py validate-modules:module-invalid-version-added
 plugins/modules/gluster_heal_info.py pylint:ansible-deprecated-no-collection-name


### PR DESCRIPTION
Created a GNU 2.0 license and updates it with (    Copyright 2014 Red Hat, Inc.)