### PR TITLE
Add support for arbiter when adding and removing bricks

### DIFF
--- a/plugins/modules/gluster_volume.py
+++ b/plugins/modules/gluster_volume.py
@@ -432,7 +432,7 @@ def reduce_config(name, removed_bricks, replica, arbiter, force):
     for line in summary:
         if 'Number' in line and int(line.split(":")[1].strip()) != 0:
             module.fail_json(msg="Operation aborted, self-heal in progress.")
-    args = ['volume', 'remove-brick', name, 'replica', str(replicas)]
+    args = ['volume', 'remove-brick', name, 'replica', str(replica)]
     if arbiter:
         args.append('arbiter')
         args.append(str(arbiter))


### PR DESCRIPTION
Adding better support for arbiter to existing gluster volumes.

The existing support only allowed arbiter to be setup on initial gluster volume creation.